### PR TITLE
allow one to use ip addresses in corosync.conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,7 @@
 ---
 pacemaker_password: hacluster
+pacemaker_ring0_addr: ansible_hostname
+# Use the IP address on the first network interface as ring0_addr in corosync.conf
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1126998
+#pacemaker_ring0_addr: ansible_all_ipv4_addresses
+#pacemaker_ring0_addr_interface: 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,18 @@
   fail: msg="Cluster hosts must be members of a group"
   when: pacemaker_ansible_group is not iterable
 
+- name: Ensure the network interface for ring0_addr is not defined when hostnames are used
+  fail: msg="If hostnames are used the network interface for ring0_addr must not be defined"
+  when: pacemaker_ring0_addr == 'ansible_hostname' and pacemaker_ring0_addr_interface is defined
+
+- name: Ensure the network interface for ring0_addr is defined when IPv4 addresses are used
+  fail: msg="If IPv4 addresses are used the network interface for ring0_addr must be defined"
+  when: pacemaker_ring0_addr == 'ansible_all_ipv4_addresses' and pacemaker_ring0_addr_interface is undefined
+
+- name: Ensure either hostnames or IPv4 addresses are used for ring0_addr
+  fail: msg="Either hostnames or IPv4 addresses must be used for ring0_addr"
+  when: not (pacemaker_ring0_addr in ['ansible_hostname', 'ansible_all_ipv4_addresses'])
+
 - name: Install Pacemaker Configuration System package
   yum: name={{ pacemaker_package }} state=installed
 
@@ -14,7 +26,7 @@
     name={{ pacemaker_user }}
     password={{ pacemaker_password | password_hash('sha512', ansible_hostname) }}
 
-- name: Authenticate all nodes
+- name: Authenticate all nodes using hostnames
   command: >
     pcs cluster auth
     {% for host in groups[pacemaker_ansible_group] %}
@@ -24,8 +36,35 @@
   run_once: true
   args:
     creates: /var/lib/pcsd/tokens
+  when: pacemaker_ring0_addr == 'ansible_hostname'
 
-- name: Setup cluster message bus
+- name: Authenticate all nodes using IPv4 addresses on the first network interace
+  command: >
+    pcs cluster auth
+    {% for host in groups[pacemaker_ansible_group] %}
+    {{ hostvars[host]['ansible_all_ipv4_addresses'][0] }}
+    {% endfor %}
+    -u {{ pacemaker_user }} -p {{ pacemaker_password }}
+  run_once: true
+  args:
+    creates: /var/lib/pcsd/tokens
+  when: (pacemaker_ring0_addr == 'ansible_all_ipv4_addresses' and
+         pacemaker_ring0_addr_interface == 0)
+
+- name: Authenticate all nodes using IPv4 addresses on the second network interace
+  command: >
+    pcs cluster auth
+    {% for host in groups[pacemaker_ansible_group] %}
+    {{ hostvars[host]['ansible_all_ipv4_addresses'][1] }}
+    {% endfor %}
+    -u {{ pacemaker_user }} -p {{ pacemaker_password }}
+  run_once: true
+  args:
+    creates: /var/lib/pcsd/tokens
+  when: (pacemaker_ring0_addr == 'ansible_all_ipv4_addresses' and
+         pacemaker_ring0_addr_interface == 1)
+
+- name: Setup cluster message bus using hostnames
   run_once: true
   command: >
     pcs cluster setup --name {{ pacemaker_cluster_name }}
@@ -34,6 +73,31 @@
     {% endfor %}
   args:
     creates: /etc/corosync/corosync.conf
+  when: pacemaker_ring0_addr == 'ansible_hostname'
+
+- name: Setup cluster message bus using IPv4 addresses on the first network interace
+  run_once: true
+  command: >
+    pcs cluster setup --name {{ pacemaker_cluster_name }}
+    {% for host in groups[pacemaker_ansible_group] %}
+    {{ hostvars[host]['ansible_all_ipv4_addresses'][0] }}
+    {% endfor %}
+  args:
+    creates: /etc/corosync/corosync.conf
+  when: (pacemaker_ring0_addr == 'ansible_all_ipv4_addresses' and
+         pacemaker_ring0_addr_interface == 0)
+
+- name: Setup cluster message bus using IPv4 addresses on the second network interace
+  run_once: true
+  command: >
+    pcs cluster setup --name {{ pacemaker_cluster_name }}
+    {% for host in groups[pacemaker_ansible_group] %}
+    {{ hostvars[host]['ansible_all_ipv4_addresses'][1] }}
+    {% endfor %}
+  args:
+    creates: /etc/corosync/corosync.conf
+  when: (pacemaker_ring0_addr == 'ansible_all_ipv4_addresses' and
+         pacemaker_ring0_addr_interface == 1)
 
 - name: Start all cluster nodes
   service: name={{ item }} enabled=yes state=started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -160,3 +160,14 @@
     {% if item.wait is defined %}
       wait={{ item.wait }}
     {% endif %}
+  args:
+    creates: /var/lib/pacemaker/pacemaker_resources_created
+  register: pacemaker_resources_created
+
+- name: Lock created resources
+  run_once: true
+  when: pacemaker_resources_created is defined and pacemaker_resources_created.changed
+  command: >
+    touch /var/lib/pacemaker/pacemaker_resources_created
+  args:
+    creates: /var/lib/pacemaker/pacemaker_resources_created


### PR DESCRIPTION
I tried to use your module in my test setup:
https://github.com/marcindulak/vagrant-haproxy-pcs-ansible-tutorial-centos7

but the cluster did not start correctly:

```
[root@lb1 ~]# pcs status
Cluster name: loadbalancer
Stack: corosync
Current DC: lb1.mydomain (version 1.1.15-11.el7_3.4-e174ec8) - partition WITHOUT quorum
Last updated: Mon Jun 26 00:55:06 2017          Last change: Mon Jun 26 00:54:51 2017 by hacluster via crmd on lb1.mydomain

2 nodes and 1 resource configured

Online: [ lb1.mydomain ]
OFFLINE: [ lb2.mydomain ]

Full list of resources:

 virtual-ip     (ocf::heartbeat:IPaddr2):       Stopped

Daemon Status:
  corosync: active/enabled
  pacemaker: active/enabled
  pcsd: active/enabled

[root@lb1 ~]# pcs status corosync

Membership information
----------------------
    Nodeid      Votes Name
         1          1 lb1.mydomain (local)

[root@lb1 ~]# nslookup lb1.mydomain
Server:		10.0.2.3
Address:	10.0.2.3#53

Name:	lb1.mydomain
Address: 192.168.123.21

[root@lb1 ~]# nslookup lb2.mydomain
Server:		10.0.2.3
Address:	10.0.2.3#53

Name:	lb2.mydomain
Address: 192.168.123.22

[root@lb2 ~]# pcs status corosync

Membership information
----------------------
    Nodeid      Votes Name
         2          1 lb2.mydomain (local)

[root@lb2 ~]# nslookup lb1.mydomain
Server:		10.0.2.3
Address:	10.0.2.3#53

Name:	lb1.mydomain
Address: 192.168.123.21

[root@lb2 ~]# nslookup lb2.mydomain
Server:		10.0.2.3
Address:	10.0.2.3#53

Name:	lb2.mydomain
Address: 192.168.123.22

```

I believe I tracked the problem to using `ansible_hostname` resulting in hostnames written into `corosync.conf`. I tried to use `hostvars[host]['ansible_fqdn']` instead without luck. However after I switched to the IP addresses the cluster starts. I'm not sure what the problem with using hostnames is, especially as https://bugzilla.redhat.com/show_bug.cgi?id=1126998 claims that using the hostnames is the right thing to do. 