### PR TITLE
fix bug with missing tempfile content by using tasks/constraints.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,37 +349,36 @@ wiki](https://wiki.clusterlabs.org/wiki/PgSQL_Replicated_Cluster).
         - name: Set up constraints
           include_role:
             name: devgateway.pacemaker
-            tasks_from: constraint
-          loop_control:
-            loop_var: pcmk_constraint
-          loop:
-            - type: colocation
-              rsc: virtual-ip
-              with-rsc: postgres
-              with-rsc-role: Master
-              score: INFINITY
-            - type: colocation
-              rsc: nginx
-              with-rsc: virtual-ip
-              score: INFINITY
-            - type: colocation
-              rsc: coolapp
-              with-rsc: virtual-ip
-              score: INFINITY
-            - type: order
-              first: postgres
-              first-action: promote
-              then: virtual-ip
-              then-action: start
-              symmetrical: false
-              score: INFINITY
-            - type: order
-              first: postgres
-              first-action: demote
-              then: virtual-ip
-              then-action: stop
-              symmetrical: false
-              score: 0
+            tasks_from: constraints
+          vars:
+            pcmk_constraints:
+              - type: colocation
+                rsc: virtual-ip
+                with-rsc: postgres
+                with-rsc-role: Master
+                score: INFINITY
+              - type: colocation
+                rsc: nginx
+                with-rsc: virtual-ip
+                score: INFINITY
+              - type: colocation
+                rsc: coolapp
+                with-rsc: virtual-ip
+                score: INFINITY
+              - type: order
+                first: postgres
+                first-action: promote
+                then: virtual-ip
+                then-action: start
+                symmetrical: false
+                score: INFINITY
+              - type: order
+                first: postgres
+                first-action: demote
+                then: virtual-ip
+                then-action: stop
+                symmetrical: false
+                score: 0
 
 ## See also
 

--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ The dictionary may contain other members, e.g. `symmetrical`.
         - name: Set up constraints
           include_role:
             name: devgateway.pacemaker
-            tasks_from: constraint
+            tasks_from: constraints
           vars:
-            pcmk_constraint:
-              type: order
-              first: dns-ip
-              then: dns-clone
+            pcmk_constraints:
+              - type: order
+                first: dns-ip
+                then: dns-clone
 
 ### Active-active Squid proxy
 
@@ -218,12 +218,12 @@ The dictionary may contain other members, e.g. `symmetrical`.
         - name: Set up constraints
           include_role:
             name: devgateway.pacemaker
-            tasks_from: constraint
+            tasks_from: constraints
           vars:
-            pcmk_constraint:
-              type: order
-              first: squid-ip
-              then: squid
+            pcmk_constraints:
+              - type: order
+                first: squid-ip
+                then: squid
 
 ### Nginx, web application, and master-slave Postgres
 

--- a/tasks/constraints.yml
+++ b/tasks/constraints.yml
@@ -1,0 +1,11 @@
+---
+- include_tasks: pre.yml
+
+- name: Configure multiple constraints
+  include_tasks: constraint.yml
+  loop_control:
+    loop_var: pcmk_constraint
+  loop: "{{ pcmk_constraints }}"
+  run_once: true
+
+- include_tasks: post.yml


### PR DESCRIPTION
Fix bug with missing tempfile content by using tasks/constraints.yml instead of tasks/constraint.yml

Without this fix, the following error is observed in ansible 2.9.x:

```
fatal: [myhost]: FAILED! => {"changed": false, "msg": "The target XML source '/tmp/ansible.xwl9wmkg.xml' does not exist."}
```

This output is observed _even if_ prior `include_role` calls had created the temp file already.  Apparently ansible cleans up tempfiles faster than it used to.